### PR TITLE
Improve chat endpoint and tests

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -142,8 +142,10 @@ def delete_articles(key):
     return jsonify(data_handler.delete_record_from_json(key))
 
 
-@app.route('/chat/<key>/', methods=['GET', 'POST'])
+@app.route('/chat/<key>/', methods=['POST'])
 def chat_by_id(key):
+    if not request.is_json or 'user' not in request.json:
+        return jsonify({"error": "Missing user in request body"}), 400
     body = request.json['user']
     return jsonify(chatbot.recursive(a=body, key=key))
 

--- a/backend/data_handler.py
+++ b/backend/data_handler.py
@@ -80,7 +80,7 @@ def delete_record_from_json(key=None):
         return data_json.error
 
 
-# the below method is used to update the new record in the flask_details data
+# the below method is used to update an existing record in the flask_details data
 def update_new_record_to_json(body, key=None):
     if key is not None and is_key_valid(key):
         body["lastUpdated"] = date
@@ -88,14 +88,14 @@ def update_new_record_to_json(body, key=None):
         write_json(json_data=json_data)
         return {
             "new updated record": body,
-            "message": "Record added successfully."
+            "message": "Record updated successfully."
         }
     else:
         data_json.error["error"] = "ID is not available to update the record"
         return data_json.error
 
 
-# add used into json file
+# add user into json file
 def add_users(body):
     # body = json.loads(body)
     user_data["Users"][body["email"]] = body

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders CodefolioHub header', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const headerElements = screen.getAllByText(/CodefolioHub/i);
+  expect(headerElements[0]).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- clarify user record update messaging and fix comment typos
- validate chat endpoint request body and restrict to POST
- update frontend test to check for CodefolioHub header

## Testing
- `python -m pytest`
- `npm test --prefix frontend -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bc555179cc832eae89eefacc83eef8