### PR TITLE
Correct achievements component naming and references

### DIFF
--- a/frontend/src/components/MainDashboard/editResume.js
+++ b/frontend/src/components/MainDashboard/editResume.js
@@ -693,7 +693,7 @@ function EditResume(props) {
                   type="text"
                   value={inputAchivement}
                   onChange={(e) => setInputAchivement(e.target.value)}
-                  placeholder="Click on Add button to add the Acheivements."
+                  placeholder="Click on Add button to add the Achievements."
                 />
               </Col>
               <Col style={{ maxWidth: "10vh" }}>

--- a/frontend/src/components/portfolios/Achievements.js
+++ b/frontend/src/components/portfolios/Achievements.js
@@ -2,12 +2,12 @@ import React from "react";
 import { Container, Row } from "react-bootstrap";
 // import FlipCard from "./flipcard";
 
-function Acheivements(props) {
+function Achievements(props) {
   const certifications =
     props.achieve && props.achieve.Certifications
       ? props.achieve.Certifications
       : [];
-  const acheivements =
+  const achievements =
     props.achieve && props.achieve.Achievements
       ? props.achieve.Achievements
       : [];
@@ -22,7 +22,7 @@ function Acheivements(props) {
         }}
       >
         <h4 className="text-decoration-underline">
-          Certifications & Acheivements
+          Certifications & Achievements
         </h4>
       </Row>
       <>
@@ -30,8 +30,8 @@ function Acheivements(props) {
         {certifications.map((item) => {
           return <p>{item}</p>;
         })}
-        <h4 className="text-decoration-underline">Acheivements: </h4>
-        {acheivements.map((item) => {
+        <h4 className="text-decoration-underline">Achievements: </h4>
+        {achievements.map((item) => {
           return <p>{item}</p>;
         })}
       </>
@@ -39,4 +39,4 @@ function Acheivements(props) {
   );
 }
 
-export default Acheivements;
+export default Achievements;

--- a/frontend/src/components/portfolios/mainpage.js
+++ b/frontend/src/components/portfolios/mainpage.js
@@ -4,7 +4,7 @@ import { Col, Container, Row, Card, Button } from "react-bootstrap";
 import Skills from "./skills";
 import Aos from "aos";
 import Projects from "./projects";
-import Acheivements from "./Acheivements";
+import Achievements from "./Achievements";
 import ChatAPIService from "../../APIServices/APIService";
 
 function Mainpage(props) {
@@ -94,8 +94,8 @@ function Mainpage(props) {
       <div id="projects" data-aos="fade">
         <Projects work={props.resume} />
       </div>
-      <div id="acheivements" data-aos="fade">
-        <Acheivements achieve={props.resume} />
+      <div id="achievements" data-aos="fade">
+        <Achievements achieve={props.resume} />
       </div>
     </>
   );

--- a/frontend/src/components/portfolios/navbar.js
+++ b/frontend/src/components/portfolios/navbar.js
@@ -22,7 +22,7 @@ function Navbarf() {
               <Nav.Link href="#home">About</Nav.Link>
               <Nav.Link href="#skills">Skills</Nav.Link>
               <Nav.Link href="#projects">Projects</Nav.Link>
-              <Nav.Link href="#acheivements">Acheivements</Nav.Link>
+              <Nav.Link href="#achievements">Achievements</Nav.Link>
             </Nav>
           </Navbar.Collapse>
           <Contact />


### PR DESCRIPTION
## Summary
- rename Acheivements component to Achievements and update internal text
- adjust main portfolio pages to reference Achievements with corrected IDs
- fix resume editor placeholder spelling for achievements

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bc5a835da0832e87f582fc0415ab64