### PR TITLE
Clarify CORS frontend origin variable

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -18,9 +18,9 @@ app = Flask(__name__)
 # Set a secret key for session management
 app.secret_key = os.urandom(24)
 
-# Configure CORS to allow requests from your frontend
-backend_url = os.getenv("BACKEND_URL")
-CORS(app, origins=[backend_url])
+# The frontend origin allowed for CORS and redirects
+frontend_url = os.getenv("FRONTEND_URL")
+CORS(app, origins=[frontend_url])
 
 # Configure SSL settings (for development)
 ssl._create_default_https_context = ssl._create_unverified_context
@@ -83,7 +83,7 @@ def logout():
     session.pop('linkedin_token', None)
     user_info = dict()
     session.clear()
-    return redirect(backend_url)
+    return redirect(frontend_url)
 
 
 @app.route('/linkedin/login/authorized')
@@ -98,7 +98,7 @@ def authorized():
     user_info = linkedin.get('userinfo').data
     # session['user_info'] = user_info
     data_handler.add_users(user_info)
-    return redirect(backend_url + '/dashboard/navbar/')
+    return redirect(frontend_url + '/dashboard/navbar/')
 
 
 @app.route('/user/login/details')


### PR DESCRIPTION
## Summary
- rename `backend_url` to `frontend_url` and expect `FRONTEND_URL` env var
- use `frontend_url` in logout and OAuth callback redirects

## Testing
- `pytest -q`
- `python -m py_compile backend/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc5aa3a2a0832eb503a87b76f86e64