### PR TITLE
test: use semantic query for header

### DIFF
--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -3,6 +3,7 @@ import App from './App';
 
 test('renders CodefolioHub header', () => {
   render(<App />);
-  const headerElements = screen.getAllByText(/CodefolioHub/i);
-  expect(headerElements[0]).toBeInTheDocument();
+  const headerElement = screen.getByRole('heading', { name: /CodefolioHub/i });
+  expect(headerElement).toBeInTheDocument();
+  expect(screen.getAllByRole('heading', { name: /CodefolioHub/i })).toHaveLength(1);
 });


### PR DESCRIPTION
## Summary
- improve header test by querying via heading role
- ensure only one `CodefolioHub` heading is rendered

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68bc5aaaf5d4832ebf4ad94ece6f6eff